### PR TITLE
feat: support sendSiteName, migrate axios to ctx.http

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,12 +5,14 @@ export interface Config {
   strict?: Computed<boolean>
   ignored?: string[]
   sendTitle: boolean
+  sendSiteNameIfNecessary: boolean
 }
 
 export const Config: Schema<Config> = Schema.object({
   strict: Schema.computed(Schema.boolean()).default(false).description('仅匹配只含链接的消息。'),
   ignored: Schema.array(Schema.string()).description('忽略特定域名的链接。'),
   sendTitle: Schema.boolean().default(false).description('同时发送标题。'),
+  sendSiteNameIfNecessary: Schema.boolean().default(false).description('标题不包含站点名的话，就发送站点名。')
 })
 
 export const name = 'OpenGraph'
@@ -41,6 +43,8 @@ export function apply(ctx: Context, config: Config) {
           return prev
         }, {} as Dict<string>)
         let message = ''
+        if (og.site_name && config.sendSiteNameIfNecessary && !og.title.toLowerCase().includes(og.site_name.toLowerCase()))
+          message += `${og.site_name}: `;
         if (og.title && config.sendTitle)
           message += `${og.title}`
         if (og.image)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Computed, Context, Dict, h, Logger, Schema } from 'koishi'
+import { Computed, Context, Dict, h, Schema } from 'koishi'
 import { load } from 'cheerio'
 
 export interface Config {
@@ -14,7 +14,7 @@ export const Config: Schema<Config> = Schema.object({
 })
 
 export const name = 'OpenGraph'
-//const logger = new Logger('OpenGraph')
+
 export function apply(ctx: Context, config: Config) {
   ctx.on('message', async (session) => {
     const regex = session.resolve(config.strict)
@@ -22,6 +22,7 @@ export function apply(ctx: Context, config: Config) {
       : /https?:\/\/\S+/g
     const match = session.content.trim().match(regex)
     if (!match) return
+
     match.forEach(async (url) => {
       if (config.ignored?.some((prefix) => url.startsWith(prefix))) return
       try {
@@ -31,6 +32,7 @@ export function apply(ctx: Context, config: Config) {
           return { body, headers }
         })
         if (!headers.get('content-type')?.startsWith('text/html')) return
+        
         const $ = load(body)
         const og = $('meta[property^="og:"]').toArray().reduce((prev, meta) => {
           const key = meta.attribs.property.slice(3)


### PR DESCRIPTION
本PR：

- 把 `ctx.http.axios` 替换成了 `fetch then` 的形式，解决 #9 
    -  之所以不用 `ctx.http.get` 是因为我不知道怎么从 `ctx.http.get` 返回的 Response 里面提取出 headers 来，它好像直接返回 Response.body 了
- `h('image', { url })` 替换成了 `h('img', { src })` 的形式，解决图片无法在一些适配器正常发送的问题
- 加了一个 标题不包含站点名就发送站点名 的功能