### PR TITLE
feat: multiple links

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Computed, Context, Dict, h, Schema } from 'koishi'
+import { Computed, Context, Dict, h, Logger, Schema } from 'koishi'
 import { load } from 'cheerio'
 
 export interface Config {
@@ -12,10 +12,12 @@ export const Config: Schema<Config> = Schema.object({
   strict: Schema.computed(Schema.boolean()).default(false).description('仅匹配只含链接的消息。'),
   ignored: Schema.array(Schema.string()).description('忽略特定域名的链接。'),
   sendTitle: Schema.boolean().default(false).description('同时发送标题。'),
-  sendSiteName: Schema.boolean().default(false).description('标题不包含站点名的话，就发送站点名。'),
+  sendSiteName: Schema.boolean().default(false).description('标题和原链接域名均不包含站点名的话，就发送站点名。'),
 })
 
 export const name = 'OpenGraph'
+
+const logger = new Logger('og')
 
 export function apply(ctx: Context, config: Config) {
   ctx.on('message', async (session) => {
@@ -25,11 +27,16 @@ export function apply(ctx: Context, config: Config) {
     const match = session.content.trim().match(regex)
     if (!match) return
 
-    match.forEach(async (url) => {
+    logger.debug('提取出的链接：', match)
+    let message = ''
+    match.forEach(async (url: string) => {
       if (config.ignored?.some((prefix) => url.startsWith(prefix))) return
       try {
         const { data, headers } = await ctx.http(url, { responseType: 'text' })
-        if (!headers.get('content-type')?.startsWith('text/html')) return
+        if (!headers.get('content-type')?.startsWith('text/html')) {
+          logger.debug(`从 ${url} 上抓取下来的数据的 content-type 不是 text/html。终止对该链接的处理流程。`)
+          return
+        }
 
         const $ = load(data)
         const og = $('meta[property^="og:"]').toArray().reduce((prev, meta) => {
@@ -38,16 +45,18 @@ export function apply(ctx: Context, config: Config) {
           if (value) prev[key] = value
           return prev
         }, {} as Dict<string>)
-        let message = ''
-        if (og.site_name && config.sendSiteName && !og.title.toLowerCase().includes(og.site_name.toLowerCase()))
-          message += `${og.site_name}: `
+        let ogblock = ''
+        if (og.site_name && config.sendSiteName && !og.title.toLowerCase().includes(og.site_name.toLowerCase()) && !(new URL(url)).host.toLowerCase().includes(og.site_name.toLowerCase()))
+          ogblock += `${og.site_name} - `
         if (og.title && config.sendTitle)
-          message += `${og.title}`
+          ogblock += `${og.title}`
         if (og.image)
-          message += h('img', { src: new URL(og.image, url).href })
-        if (message !== '')
-          await session.send(message)
+          ogblock += h('img', { src: new URL(og.image, url).href })
+        logger.debug(`从 ${url} 生成了预览：${ogblock}`)
+        if (ogblock !== '')
+          message += `${ogblock}\n`
       } catch {}
     })
+    await session.send(message)
   })
 }


### PR DESCRIPTION
- 对于单条消息的多个链接，把多个链接的解析结果合并到一个消息中以避免潜在地刷屏
- 发送站点名的条件改成了 “标题和原链接域名均不包含站点名”
- 增加 debug 用 logger ，对我以后调试og很有帮助